### PR TITLE
fix contact href in links.html

### DIFF
--- a/partials/links.html
+++ b/partials/links.html
@@ -1,7 +1,7 @@
 <ul>
   {{#each languages }}
     <li>
-      <a href=/{{ @key }}>{{ this }} Contact</a>
+      <a href="/{{ @key }}">{{ this }} Contact</a>
     </li>
   {{/each }}
   <li>


### PR DESCRIPTION
the lack of double quotes was preventing the find-and-replace task used to qualify absolute links from working properly.
